### PR TITLE
post numpy 1.7, the pandas datetime should called "datetime64"

### DIFF
--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -64,7 +64,7 @@ def feast_value_type_to_pandas_type(value_type: ValueType) -> Any:
         ValueType.DOUBLE: "float",
         ValueType.BYTES: "bytes",
         ValueType.BOOL: "bool",
-        ValueType.UNIX_TIMESTAMP: "datetime",
+        ValueType.UNIX_TIMESTAMP: "datetime64",
     }
     if value_type.name.endswith("_LIST"):
         return "object"

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -50,6 +50,7 @@ REQUIRED = [
     "grpcio-reflection>=1.34.0",
     "Jinja2>=2.0.0",
     "jsonschema",
+    "numpy>=1.7",
     "mmh3",
     "pandas>=1.0.0",
     "pandavro==1.5.*",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


```
  File "/Users/zf/go/src/github.com/opendoor-labs/code/py/lib/feature_store/.venv/lib/python3.9/site-packages/feast/cli.py", line 369, in apply_total_command
    apply_total(repo_config, repo, skip_source_validation)
  File "/Users/zf/go/src/github.com/opendoor-labs/code/py/lib/feature_store/.venv/lib/python3.9/site-packages/feast/usage.py", line 269, in wrapper
    return func(*args, **kwargs)
  File "/Users/zf/go/src/github.com/opendoor-labs/code/py/lib/feature_store/.venv/lib/python3.9/site-packages/feast/repo_operations.py", line 194, in apply_total
    store.apply(all_to_apply, objects_to_delete=all_to_delete, partial=False)
  File "/Users/zf/go/src/github.com/opendoor-labs/code/py/lib/feature_store/.venv/lib/python3.9/site-packages/feast/usage.py", line 280, in wrapper
    raise exc.with_traceback(traceback)
  File "/Users/zf/go/src/github.com/opendoor-labs/code/py/lib/feature_store/.venv/lib/python3.9/site-packages/feast/usage.py", line 269, in wrapper
    return func(*args, **kwargs)
  File "/Users/zf/go/src/github.com/opendoor-labs/code/py/lib/feature_store/.venv/lib/python3.9/site-packages/feast/feature_store.py", line 484, in apply
    odfv.infer_features()
  File "/Users/zf/go/src/github.com/opendoor-labs/code/py/lib/feature_store/.venv/lib/python3.9/site-packages/feast/on_demand_feature_view.py", line 201, in infer_features
    df[f"{feature_view.name}__{feature.name}"] = pd.Series(dtype=dtype)
  File "/Users/zf/go/src/github.com/opendoor-labs/code/py/lib/feature_store/.venv/lib/python3.9/site-packages/pandas/core/series.py", line 373, in __init__
    dtype = self._validate_dtype(dtype)
  File "/Users/zf/go/src/github.com/opendoor-labs/code/py/lib/feature_store/.venv/lib/python3.9/site-packages/pandas/core/generic.py", line 442, in _validate_dtype
    dtype = pandas_dtype(dtype)
  File "/Users/zf/go/src/github.com/opendoor-labs/code/py/lib/feature_store/.venv/lib/python3.9/site-packages/pandas/core/dtypes/common.py", line 1776, in pandas_dtype
    npdtype = np.dtype(dtype)
TypeError: data type 'datetime' not understood
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
